### PR TITLE
Remove Strava athletic activity from current list

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,9 @@
 {
     "cSpell.words": [
         "amoscato",
-        "consts",
         "Fieldguide",
         "Hasura",
         "Postgres",
-        "strava",
         "stylelint"
     ],
     "typescript.tsdk": "node_modules/typescript/lib",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md
+
+This file provides guidance to coding agents when working with code in this repository.
+
+## Overview
+
+Front end for [amoscato.com](https://amoscato.com/), a personal site built with [Hugo](https://gohugo.io/) and TypeScript. Requires Node 22 (`.nvmrc`) and the Hugo CLI.
+
+## Commands
+
+-   `npm start` — runs `hugo serve` and `tsc --noEmit --watch` concurrently
+-   `npm run build` — production build (`hugo --gc --minify`)
+-   `npm test` — runs Jest; `posttest` then runs all linters (`lint-js`, `prettier`, `lint-sass`), matching CI
+-   `npx jest assets/js/stream/__tests__/square.test.ts` — run a single test file (or `npx jest -t "test name"`)
+-   `npm run lint-js` — `tsc --noEmit` type check + ESLint
+-   `npm run lint-sass` — stylelint on `assets/**/*.scss`
+-   `npm run prettier` / `npm run prettier:fix` — check / fix formatting
+
+## Architecture
+
+Hugo compiles the assets itself — there is no webpack/standalone bundler config:
+
+-   `layouts/_default/baseof.html` is where asset compilation is wired up. TypeScript is bundled from the `assets/js/app.ts` entry point via Hugo's `js.Build` (esbuild), and SCSS is compiled from `assets/css/app.scss` via `css.Sass`.
+-   jQuery, moment, and onecolor are loaded from CDNs as globals, not bundled. `assets/js/shims/` maps bare imports (`import $ from "jquery"`) to those globals through the `shims` option of `js.Build`. Keep this in mind when adding dependencies.
+-   Build-time parameters are injected via `js.Build`'s `params` option and imported as `import * as params from "@params"` (typed in `assets/js/@params.d.ts`). Currently this carries `cacheBaseUri` (`https://storage.amoscato.com`), the backend that serves the JSON data feeds.
+-   `tsc` is type-check only (`noEmit`); Jest transpiles tests with Babel (`.babelrc`, `@babel/preset-typescript`), so type errors won't fail Jest — they surface via `lint-js`.
+
+### Runtime behavior (homepage)
+
+`app.ts` powers two homepage features, each fetching pre-aggregated JSON from `storage.amoscato.com`:
+
+-   `assets/js/current-list/` — the "Currently" list. Renders one line per source (journal, music, book, video, drink) from `current.json`; the journal entry is injected from Hugo `data-` attributes on `#homepage-currently` rather than the JSON.
+-   `assets/js/stream/` — the visual footer mosaic. `Stream` lays out `StreamColumn`s of colored squares/photos from `stream.json` across the window width, re-rendering on debounced window resize. Colors and sizing come from the `IStreamConfiguration` defined in `app.ts`.
+
+### Hugo content
+
+-   `content/journal/` — blog posts, rendered by `layouts/journal/single.html`; the homepage pulls the latest post into the current list.
+-   Site config lives in `config.yaml`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/assets/js/app.ts
+++ b/assets/js/app.ts
@@ -11,7 +11,6 @@ const windowElement = $(window);
 const currentListSources: string[] = [
     "journal",
     "music",
-    "athleticActivity",
     "book",
     "video",
     "drink",

--- a/assets/js/current-list/__tests__/index.test.ts
+++ b/assets/js/current-list/__tests__/index.test.ts
@@ -43,58 +43,12 @@ describe("CurrentList", () => {
             });
         });
 
-        describe("bike ride", () => {
+        describe("missing source", () => {
             beforeEach(() => {
-                target = new CurrentList(["athleticActivity"], {
-                    athleticActivity: {
-                        date: "activity date",
-                        miles: 1.235,
-                        minutes: 30.1,
-                        type: "Ride",
-                        url: "strava url",
-                    },
-                });
+                target = new CurrentList(["book"], {});
             });
 
-            it("should generate HTML", () => {
-                expect(target.getHtml()).toEqual(
-                    '<li class="homepage-current-list-item" title="in 31 minutes, formatted activity date">biking <a href="strava url" target="_blank">1.23 miles</a></li>',
-                );
-            });
-        });
-
-        describe("run", () => {
-            beforeEach(() => {
-                target = new CurrentList(["athleticActivity"], {
-                    athleticActivity: {
-                        date: "activity date",
-                        miles: 1.235,
-                        minutes: 30.1,
-                        type: "Run",
-                        url: "strava url",
-                    },
-                });
-            });
-
-            it("should generate HTML", () => {
-                expect(target.getHtml()).toContain(">running <");
-            });
-        });
-
-        describe("unexpected athletic activity", () => {
-            beforeEach(() => {
-                target = new CurrentList(["athleticActivity"], {
-                    athleticActivity: {
-                        date: "activity date",
-                        miles: 1.235,
-                        minutes: 30.1,
-                        type: "Swim",
-                        url: "strava url",
-                    },
-                });
-            });
-
-            it("should generate HTML", () => {
+            it("should generate empty HTML", () => {
                 expect(target.getHtml()).toEqual("");
             });
         });

--- a/assets/js/current-list/consts.ts
+++ b/assets/js/current-list/consts.ts
@@ -1,5 +1,0 @@
-export const STRAVA_TYPE_VERB_MAP = {
-    Ride: "biking",
-    Run: "running",
-    Walk: "walking",
-} as const;

--- a/assets/js/current-list/index.ts
+++ b/assets/js/current-list/index.ts
@@ -1,5 +1,4 @@
 import moment from "moment";
-import { STRAVA_TYPE_VERB_MAP } from "./consts";
 import { ListItem } from "./types";
 
 export default class CurrentList {
@@ -12,7 +11,7 @@ export default class CurrentList {
         sources.forEach((source) => {
             const item = data[source];
 
-            if (item !== null) {
+            if (item != null) {
                 this.html += this.getSourceHtml(source, item);
             }
         });
@@ -48,23 +47,6 @@ export default class CurrentList {
      */
     private getSourceHtml(source: string, item: any): string {
         switch (source) {
-            case "athleticActivity": {
-                const stravaType =
-                    item.type as keyof typeof STRAVA_TYPE_VERB_MAP;
-
-                if ("undefined" === typeof STRAVA_TYPE_VERB_MAP[stravaType]) {
-                    return "";
-                }
-
-                return this.getListItemHtml({
-                    title: `${Math.floor(100 * item.miles) / 100} miles`,
-                    tooltip: `in ${Math.ceil(
-                        item.minutes,
-                    )} minutes, ${this.formatDate(item.date)}`,
-                    url: item.url,
-                    verb: STRAVA_TYPE_VERB_MAP[stravaType],
-                });
-            }
             case "book":
                 return this.getListItemHtml({
                     title: this.quoteText(item.title),


### PR DESCRIPTION
## Summary

- Remove the `athleticActivity` source from the current list and delete the Strava activity-type verb mapping, matching the server-side removal of the Strava integration (namoscato/amoscato-server#578)
- Loosen the current list's null check (`!= null`) so sources missing entirely from `current.json` are skipped instead of rendering
- Add `AGENTS.md` documenting commands and architecture for AI coding agents, with `CLAUDE.md` symlinked to it

## Testing

- `npm test` — jest, tsc, eslint, prettier, and stylelint all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
